### PR TITLE
added a color handler to thiscovery logger to facilitate distinguishing between INFO log messages and errors

### DIFF
--- a/api/common/log_color_handler.py
+++ b/api/common/log_color_handler.py
@@ -1,0 +1,81 @@
+# from https://xsnippet.org/359377/
+# with modifications described in https://stackoverflow.com/a/55724913
+
+import sys
+import logging
+
+
+class _AnsiColorizer(object):
+    """
+    A colorizer is an object that loosely wraps around a stream, allowing
+    callers to write text to the stream in a particular color.
+
+    Colorizer classes must implement C{supported()} and C{write(text, color)}.
+    """
+    _colors = dict(black=30, red=31, green=32, yellow=33,
+                   blue=34, magenta=35, cyan=36, white=37)
+
+    def __init__(self, stream):
+        self.stream = stream
+
+    @classmethod
+    def supported(cls, stream=sys.stdout):
+        """
+        A class method that returns True if the current platform supports
+        coloring terminal output using this method. Returns False otherwise.
+        """
+        if not stream.isatty():
+            return False  # auto color only on TTYs
+        try:
+            import curses
+        except ImportError:
+            return False
+        else:
+            try:
+                try:
+                    return curses.tigetnum("colors") > 2
+                except curses.error:
+                    curses.setupterm()
+                    return curses.tigetnum("colors") > 2
+            except:
+                raise
+                # guess false in case of error
+                return False
+
+    def write(self, text, color):
+        """
+        Write the given text to the stream in the given color.
+
+        @param text: Text to be written to the stream.
+
+        @param color: A string label for a color. e.g. 'red', 'white'.
+        """
+        color = self._colors[color]
+        self.stream.write('\x1b[%s;1m%s\x1b[0m' % (color, text))
+
+
+class ColorHandler(logging.StreamHandler):
+    def __init__(self, stream=sys.stderr):
+        super(ColorHandler, self).__init__(_AnsiColorizer(stream))
+
+    def emit(self, record):
+        msg_colors = {
+            logging.DEBUG: "green",
+            logging.INFO: "blue",
+            logging.WARNING: "yellow",
+            logging.ERROR: "red"
+        }
+
+        color = msg_colors.get(record.levelno, "blue")
+        self.stream.write(self.format(record) + "\n", color)
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.DEBUG)
+    logging.getLogger().addHandler(ColorHandler())
+
+    logging.debug("Some debugging output")
+    logging.info("Some info output")
+    logging.error("Some error output")
+    logging.warning("Some warning output")
+

--- a/api/common/utilities.py
+++ b/api/common/utilities.py
@@ -29,6 +29,7 @@ import json
 import boto3
 from botocore.exceptions import ClientError
 
+from common.log_color_handler import ColorHandler
 
 # region Custom error classes and handling
 
@@ -187,8 +188,7 @@ def get_logger():
     global logger
     if logger is None:
         logger = logging.getLogger('thiscovery')
-        # print('creating logger')
-        log_handler = logging.StreamHandler()
+        log_handler = ColorHandler()
         formatter = jsonlogger.JsonFormatter('%(asctime)s %(module)s %(funcName)s %(lineno)d %(name)-2s %(levelname)-8s %(message)s')
         formatter.default_msec_format = '%s.%03d'
         log_handler.setFormatter(formatter)


### PR DESCRIPTION
Side effect of this change: CloudWatch logs will start with a definition of the colour, for example, "[34;1m"

Here is a complete example of an event log:

master branch:     {"asctime": "2019-12-23 14:15:04.469", "module": "user", "funcName": "create_user_api", "lineno": 398, "name": "thiscovery", "levelname": "INFO", "message": "API call", "user_json": {"id": "48e30e54-b4fc-4303-963f-2943dda2b139", "created": "2018-08-21T11:16:56+01:00", "email": "sw@email.co.uk", "email_address_verified": false, "title": "Mr", "first_name": "Steven", "last_name": "Walcorn", "auth0_id": "1234abcd", "country_code": "GB", "crm_id": null, "status": "new"}, "correlation_id": "00080a80-63de-4a73-84ac-0a513e626b8e", "event": {"resource": "/v1/user", "path": "/v1/user", "httpMethod": "POST", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Content-Type": "application/json", "Host": "test-afs25-api.thiscovery.org", "User-Agent": "python-requests/2.22.0", "X-Amzn-Trace-Id": "Root=1-5e00cbe7-865c29c978bd00c0cdbe4dd9", "x-api-key": "pSCX0B1uMN2Aai3uW5OhX3sg7lbiLPUv1RShAXxg", "X-Forwarded-For": "92.27.127.244", "X-Forwarded-Port": "443", "X-Forwarded-Proto": "https"}, "multiValueHeaders": {"Accept": ["*/*"], "Accept-Encoding": ["gzip, deflate"], "Content-Type": ["application/json"], "Host": ["test-afs25-api.thiscovery.org"], "User-Agent": ["python-requests/2.22.0"], "X-Amzn-Trace-Id": ["Root=1-5e00cbe7-865c29c978bd00c0cdbe4dd9"], "x-api-key": ["pSCX0B1uMN2Aai3uW5OhX3sg7lbiLPUv1RShAXxg"], "X-Forwarded-For": ["92.27.127.244"], "X-Forwarded-Port": ["443"], "X-Forwarded-Proto": ["https"]}, "queryStringParameters": null, "multiValueQueryStringParameters": null, "pathParameters": null, "stageVariables": null, "requestContext": {"resourceId": "vimo98", "resourcePath": "/v1/user", "httpMethod": "POST", "extendedRequestId": "FKTMKEP_joEF6wQ=", "requestTime": "23/Dec/2019:14:15:03 +0000", "path": "/v1/user", "accountId": "595383251813", "protocol": "HTTP/1.1", "stage": "test_afs25", "domainPrefix": "test-afs25-api", "requestTimeEpoch": 1577110503396, "requestId": "9ce3807c-5562-4bb2-902c-cf5a323dce19", "identity": {"cognitoIdentityPoolId": null, "cognitoIdentityId": null, "apiKey": "pSCX0B1uMN2Aai3uW5OhX3sg7lbiLPUv1RShAXxg", "principalOrgId": null, "cognitoAuthenticationType": null, "userArn": null, "apiKeyId": "ujtgn3be02", "userAgent": "python-requests/2.22.0", "accountId": null, "caller": null, "sourceIp": "92.27.127.244", "accessKey": null, "cognitoAuthenticationProvider": null, "user": null}, "domainName": "test-afs25-api.thiscovery.org", "apiId": "w80arj9alc"}, "body": "{\"id\": \"48e30e54-b4fc-4303-963f-2943dda2b139\", \"created\": \"2018-08-21T11:16:56+01:00\", \"email\": \"sw@email.co.uk\", \"email_address_verified\": false, \"title\": \"Mr\", \"first_name\": \"Steven\", \"last_name\": \"Walcorn\", \"auth0_id\": \"1234abcd\", \"country_code\": \"GB\", \"crm_id\": null, \"status\": \"new\"}", "isBase64Encoded": false}}

this branch: [34;1m{"asctime": "2019-12-23 14:01:01.731", "module": "user", "funcName": "create_user_api", "lineno": 398, "name": "thiscovery", "levelname": "INFO", "message": "API call", "user_json": {"id": "48e30e54-b4fc-4303-963f-2943dda2b139", "created": "2018-08-21T11:16:56+01:00", "email": "sw@email.co.uk", "email_address_verified": false, "title": "Mr", "first_name": "Steven", "last_name": "Walcorn", "auth0_id": "1234abcd", "country_code": "GB", "crm_id": null, "status": "new"}, "correlation_id": "65c38684-bbb7-4e9e-84a6-dca219e426b8", "event": {"resource": "/v1/user", "path": "/v1/user", "httpMethod": "POST", "headers": {"Accept": "*/*", "Accept-Encoding": "gzip, deflate", "Content-Type": "application/json", "Host": "test-afs25-api.thiscovery.org", "User-Agent": "python-requests/2.22.0", "X-Amzn-Trace-Id": "Root=1-5e00c89c-fb415990d3c9e7d4552949c0", "x-api-key": "pSCX0B1uMN2Aai3uW5OhX3sg7lbiLPUv1RShAXxg", "X-Forwarded-For": "92.27.127.244", "X-Forwarded-Port": "443", "X-Forwarded-Proto": "https"}, "multiValueHeaders": {"Accept": ["*/*"], "Accept-Encoding": ["gzip, deflate"], "Content-Type": ["application/json"], "Host": ["test-afs25-api.thiscovery.org"], "User-Agent": ["python-requests/2.22.0"], "X-Amzn-Trace-Id": ["Root=1-5e00c89c-fb415990d3c9e7d4552949c0"], "x-api-key": ["pSCX0B1uMN2Aai3uW5OhX3sg7lbiLPUv1RShAXxg"], "X-Forwarded-For": ["92.27.127.244"], "X-Forwarded-Port": ["443"], "X-Forwarded-Proto": ["https"]}, "queryStringParameters": null, "multiValueQueryStringParameters": null, "pathParameters": null, "stageVariables": null, "requestContext": {"resourceId": "vimo98", "resourcePath": "/v1/user", "httpMethod": "POST", "extendedRequestId": "FKRIfHgqjoEFXGw=", "requestTime": "23/Dec/2019:14:01:00 +0000", "path": "/v1/user", "accountId": "595383251813", "protocol": "HTTP/1.1", "stage": "test_afs25", "domainPrefix": "test-afs25-api", "requestTimeEpoch": 1577109660627, "requestId": "e9b03847-4cd9-4dfc-abdc-f3cc3f548699", "identity": {"cognitoIdentityPoolId": null, "cognitoIdentityId": null, "apiKey": "pSCX0B1uMN2Aai3uW5OhX3sg7lbiLPUv1RShAXxg", "principalOrgId": null, "cognitoAuthenticationType": null, "userArn": null, "apiKeyId": "ujtgn3be02", "userAgent": "python-requests/2.22.0", "accountId": null, "caller": null, "sourceIp": "92.27.127.244", "accessKey": null, "cognitoAuthenticationProvider": null, "user": null}, "domainName": "test-afs25-api.thiscovery.org", "apiId": "w80arj9alc"}, "body": "{\"id\": \"48e30e54-b4fc-4303-963f-2943dda2b139\", \"created\": \"2018-08-21T11:16:56+01:00\", \"email\": \"sw@email.co.uk\", \"email_address_verified\": false, \"title\": \"Mr\", \"first_name\": \"Steven\", \"last_name\": \"Walcorn\", \"auth0_id\": \"1234abcd\", \"country_code\": \"GB\", \"crm_id\": null, \"status\": \"new\"}", "isBase64Encoded": false}}

 