### PR TITLE
2896 rationalise sql and put in separate file

### DIFF
--- a/api/common/sql_queries.py
+++ b/api/common/sql_queries.py
@@ -1,3 +1,5 @@
+from jinja2 import Template
+
 # region project
 BASE_PROJECT_SELECT_SQL = '''
     SELECT row_to_json(project_row) 
@@ -158,69 +160,46 @@ PROJECT_USER_SELECT_SQL = '''
         ) project_row
     '''
 
-get_project_status_for_user_sql = {
-    'sql0': """
-        SELECT project_id, project_name, group_id, group_name, user_id, email
+
+get_project_status_for_user_template = {
+    'sql0': Template("""
+        SELECT project_id, project_name, group_id, group_name, user_id, email{{ extra_columns }}
         FROM public.project_group_users
-        WHERE user_id = %s
-    """,
+        WHERE {{ filter }} = %s
+    """),
 
-    'sql1': """
-        SELECT project_id, project_name, testing_group_id, group_name, user_id, email
+    'sql1': Template("""
+        SELECT project_id, project_name, testing_group_id, group_name, user_id, email{{ extra_columns }}
         FROM public.project_testgroup_users
-        WHERE user_id = %s
-    """,
+        WHERE {{ filter }} = %s
+    """),
 
-    'sql2': """
-        SELECT project_task_id, description, group_id, group_name, user_id, email
+    'sql2': Template("""
+        SELECT project_task_id, description, group_id, group_name, user_id, email{{ extra_columns }}
         FROM public.projecttask_group_users
-        WHERE user_id = %s
-    """,
+        WHERE {{ filter }} = %s
+    """),
 
-    'sql3': """
-        SELECT project_task_id, description, testing_group_id, group_name, user_id, email
+    'sql3': Template("""
+        SELECT project_task_id, description, testing_group_id, group_name, user_id, email{{ extra_columns }}
         FROM public.projecttask_testgroup_users
-        WHERE user_id = %s
-    """,
+        WHERE {{ filter }} = %s
+    """),
 
-    'sql4': """
-        SELECT project_task_id, ut.id, ut.status
+    'sql4': Template("""
+        SELECT project_task_id, ut.id, ut.status{{ extra_columns }}
         FROM public.projects_usertask ut
         JOIN public.projects_userproject up ON ut.user_project_id = up.id
-        WHERE up.user_id = %s
-    """,
+        WHERE {{ filter }} = %s
+    """),
 }
 
-get_project_status_for_external_user_sql = {
-    'sql0': """
-        SELECT project_id, project_name, group_id, group_name, user_id, email, ext_user_project_id
-        FROM public.project_group_users
-        WHERE ext_user_project_id = %s
-    """,
+get_project_status_for_user_sql = {k: v.render(filter='user_id') for k, v in get_project_status_for_user_template.items()}
+get_project_status_for_user_sql['sql4'] = get_project_status_for_user_template['sql4'].render(filter='up.user_id')
 
-    'sql1': """
-        SELECT project_id, project_name, testing_group_id, group_name, user_id, email, ext_user_project_id
-        FROM public.project_testgroup_users
-        WHERE ext_user_project_id = %s
-    """,
-
-    'sql2': """
-        SELECT project_task_id, description, group_id, group_name, user_id, email, ext_user_project_id
-        FROM public.projecttask_group_users
-        WHERE ext_user_project_id = %s
-    """,
-
-    'sql3': """
-        SELECT project_task_id, description, testing_group_id, group_name, user_id, email, ext_user_project_id
-        FROM public.projecttask_testgroup_users
-        WHERE ext_user_project_id = %s
-    """,
-
-    'sql4': """
-        SELECT project_task_id, ut.id, ut.status, up.ext_user_project_id as ext_user_project_id, ut.ext_user_task_id as ext_user_task_id 
-        FROM public.projects_usertask ut
-        JOIN public.projects_userproject up ON ut.user_project_id = up.id
-        WHERE ext_user_project_id = %s
-    """,
-}
+get_project_status_for_external_user_sql = {k: v.render(extra_columns=', ext_user_project_id', filter='ext_user_project_id') for k, v in
+                                            get_project_status_for_user_template.items()}
+get_project_status_for_external_user_sql['sql4'] = get_project_status_for_user_template['sql4'].render(
+    extra_columns=', up.ext_user_project_id as ext_user_project_id, ut.ext_user_task_id as ext_user_task_id',
+    filter='ext_user_project_id')
 # endregion

--- a/api/common/sql_queries.py
+++ b/api/common/sql_queries.py
@@ -1,0 +1,226 @@
+# region project
+BASE_PROJECT_SELECT_SQL = '''
+    SELECT row_to_json(project_row) 
+    from (
+        select 
+            id, 
+            name,
+            short_name,
+            created,
+            modified,
+            visibility,
+            status,
+            (
+                select coalesce(json_agg(task_row), '[]'::json)
+                from (
+                    select 
+                        id,
+                        description,
+                        created,
+                        modified,
+                        task_type_id,
+                        earliest_start_date,
+                        closing_date,
+                        signup_status,
+                        visibility,
+                        external_system_id,                       
+                        external_task_id, 
+                        base_url,                      
+                        status                         
+                    from public.projects_projecttask task
+                    where task.project_id = project.id
+                        AND task.status != 'planned'
+                    order by created
+                    ) task_row
+            ) as tasks
+        from public.projects_project project
+        where project.status != 'planned'
+        order by created
+        ) project_row
+'''
+
+MINIMAL_PROJECT_SELECT_SQL = '''
+    SELECT row_to_json(project_row) 
+    from (
+        select 
+            id, 
+            short_name,
+            visibility,
+            status,
+            (
+                select coalesce(json_agg(task_row), '[]'::json)
+                from (
+                    select 
+                        id,
+                        description,
+                        signup_status,
+                        visibility,
+                        status                         
+                    from public.projects_projecttask task
+                    where task.project_id = project.id
+                        AND task.status != 'planned'
+                    order by created
+                    ) task_row
+            ) as tasks
+        from public.projects_project project
+        where project.status != 'planned'
+        order by created
+        ) project_row
+'''
+
+TASKS_BY_EXTERNAL_ID_SQL = '''
+            SELECT
+                pt.id,
+                project_id,
+                task_type_id,
+                base_url,
+                external_system_id,
+                external_task_id,
+                es.short_name as task_provider_name
+            FROM public.projects_projecttask pt
+            JOIN projects_externalsystem es on pt.external_system_id = es.id
+            WHERE external_task_id = (%s)
+    '''
+
+LIST_PROJECTS_SQL = '''
+      SELECT 
+        id, 
+        name,
+        short_name,
+        created,
+        modified,
+        visibility,
+        status
+      FROM 
+        public.projects_project
+      WHERE projects_project.status != 'planned'
+      ORDER BY 
+        created
+    '''
+
+GET_PROJECT_TASK_SQL = '''
+        SELECT
+            pt.id as project_task_id,
+            project_id,
+            task_type_id,
+            base_url,
+            external_system_id,
+            external_task_id,
+            progress_info,
+            progress_info_modified,
+            es.short_name as task_provider_name
+        FROM public.projects_projecttask pt
+        JOIN projects_externalsystem es on pt.external_system_id = es.id
+        WHERE pt.id = %s
+    '''
+
+UPDATE_PROJECT_TASK_PROGRESS_INFO_SQL = '''
+                UPDATE public.projects_projecttask
+                SET progress_info = (%s), progress_info_modified = (%s)
+                WHERE id = (%s);
+            '''
+
+PROJECT_USER_SELECT_SQL = '''
+    SELECT row_to_json(project_row) 
+    from (
+        select 
+            id, 
+            short_name,
+            visibility,
+            status,
+            FALSE as project_is_visible,
+            (
+                select coalesce(json_agg(task_row), '[]'::json)
+                from (
+                    select 
+                        task.id,
+                        description,
+                        signup_status,
+                        visibility,   
+                        external_task_id,
+                        base_url as url,                    
+                        status,
+                        es.short_name as task_provider_name,
+                        FALSE as task_is_visible,
+                        FALSE as user_is_signedup,
+                        FALSE as signup_available,
+                        null as user_task_status
+                    from public.projects_projecttask task
+                    join public.projects_externalsystem es on task.external_system_id = es.id
+                    where task.project_id = project.id
+                        AND task.status != 'planned'                   
+                    order by task.created
+                    ) task_row
+            ) as tasks
+        from public.projects_project project
+        where project.status != 'planned'
+        order by created
+        ) project_row
+    '''
+
+get_project_status_for_user_sql = {
+    'sql0': """
+        SELECT project_id, project_name, group_id, group_name, user_id, email
+        FROM public.project_group_users
+        WHERE user_id = %s
+    """,
+
+    'sql1': """
+        SELECT project_id, project_name, testing_group_id, group_name, user_id, email
+        FROM public.project_testgroup_users
+        WHERE user_id = %s
+    """,
+
+    'sql2': """
+        SELECT project_task_id, description, group_id, group_name, user_id, email
+        FROM public.projecttask_group_users
+        WHERE user_id = %s
+    """,
+
+    'sql3': """
+        SELECT project_task_id, description, testing_group_id, group_name, user_id, email
+        FROM public.projecttask_testgroup_users
+        WHERE user_id = %s
+    """,
+
+    'sql4': """
+        SELECT project_task_id, ut.id, ut.status
+        FROM public.projects_usertask ut
+        JOIN public.projects_userproject up ON ut.user_project_id = up.id
+        WHERE up.user_id = %s
+    """,
+}
+
+get_project_status_for_external_user_sql = {
+    'sql0': """
+        SELECT project_id, project_name, group_id, group_name, user_id, email, ext_user_project_id
+        FROM public.project_group_users
+        WHERE ext_user_project_id = %s
+    """,
+
+    'sql1': """
+        SELECT project_id, project_name, testing_group_id, group_name, user_id, email, ext_user_project_id
+        FROM public.project_testgroup_users
+        WHERE ext_user_project_id = %s
+    """,
+
+    'sql2': """
+        SELECT project_task_id, description, group_id, group_name, user_id, email, ext_user_project_id
+        FROM public.projecttask_group_users
+        WHERE ext_user_project_id = %s
+    """,
+
+    'sql3': """
+        SELECT project_task_id, description, testing_group_id, group_name, user_id, email, ext_user_project_id
+        FROM public.projecttask_testgroup_users
+        WHERE ext_user_project_id = %s
+    """,
+
+    'sql4': """
+        SELECT project_task_id, ut.id, ut.status, up.ext_user_project_id as ext_user_project_id, ut.ext_user_task_id as ext_user_task_id 
+        FROM public.projects_usertask ut
+        JOIN public.projects_userproject up ON ut.user_project_id = up.id
+        WHERE ext_user_project_id = %s
+    """,
+}
+# endregion

--- a/api/endpoints/project.py
+++ b/api/endpoints/project.py
@@ -20,119 +20,18 @@ import json
 from http import HTTPStatus
 
 from common.pg_utilities import execute_query, execute_query_multiple, dict_from_dataset, execute_non_query
+from common.sql_queries import BASE_PROJECT_SELECT_SQL, MINIMAL_PROJECT_SELECT_SQL, TASKS_BY_EXTERNAL_ID_SQL, LIST_PROJECTS_SQL, GET_PROJECT_TASK_SQL, \
+    UPDATE_PROJECT_TASK_PROGRESS_INFO_SQL, PROJECT_USER_SELECT_SQL, get_project_status_for_user_sql, get_project_status_for_external_user_sql
 from common.utilities import get_correlation_id, get_logger, error_as_response_body, ObjectDoesNotExistError, get_start_time, get_elapsed_ms, \
     triggered_by_heartbeat, non_prod_env_url_param, create_url_params, create_anonymous_url_params
 
 
-BASE_PROJECT_SELECT_SQL = '''
-    SELECT row_to_json(project_row) 
-    from (
-        select 
-            id, 
-            name,
-            short_name,
-            created,
-            modified,
-            visibility,
-            status,
-            (
-                select coalesce(json_agg(task_row), '[]'::json)
-                from (
-                    select 
-                        id,
-                        description,
-                        created,
-                        modified,
-                        task_type_id,
-                        earliest_start_date,
-                        closing_date,
-                        signup_status,
-                        visibility,
-                        external_system_id,                       
-                        external_task_id, 
-                        base_url,                      
-                        status                         
-                    from public.projects_projecttask task
-                    where task.project_id = project.id
-                        AND task.status != 'planned'
-                    order by created
-                    ) task_row
-            ) as tasks
-        from public.projects_project project
-        where project.status != 'planned'
-        order by created
-        ) project_row
-'''
-
-MINIMAL_PROJECT_SELECT_SQL = '''
-    SELECT row_to_json(project_row) 
-    from (
-        select 
-            id, 
-            short_name,
-            visibility,
-            status,
-            (
-                select coalesce(json_agg(task_row), '[]'::json)
-                from (
-                    select 
-                        id,
-                        description,
-                        signup_status,
-                        visibility,
-                        status                         
-                    from public.projects_projecttask task
-                    where task.project_id = project.id
-                        AND task.status != 'planned'
-                    order by created
-                    ) task_row
-            ) as tasks
-        from public.projects_project project
-        where project.status != 'planned'
-        order by created
-        ) project_row
-'''
+def list_projects(correlation_id=None):
+    return execute_query(LIST_PROJECTS_SQL, None, correlation_id)
 
 
-TASKS_BY_EXTERNAL_ID_SQL = '''
-            SELECT
-                pt.id,
-                project_id,
-                task_type_id,
-                base_url,
-                external_system_id,
-                external_task_id,
-                es.short_name as task_provider_name
-            FROM public.projects_projecttask pt
-            JOIN projects_externalsystem es on pt.external_system_id = es.id
-            WHERE external_task_id = (%s)
-    '''
-
-
-def list_projects(correlation_id):
-    base_sql = '''
-      SELECT 
-        id, 
-        name,
-        short_name,
-        created,
-        modified,
-        visibility,
-        status
-      FROM 
-        public.projects_project
-      WHERE projects_project.status != 'planned'
-      ORDER BY 
-        created
-    '''
-
-    return execute_query(base_sql, None, correlation_id)
-
-
-def list_projects_with_tasks(correlation_id):
-
+def list_projects_with_tasks(correlation_id=None):
     result = execute_query(BASE_PROJECT_SELECT_SQL, None, correlation_id, True, False)
-
     return result
 
 
@@ -163,38 +62,17 @@ def list_projects_api(event, context):
 
 
 def get_project_task(project_task_id, correlation_id=None):
-    sql = '''
-        SELECT
-            pt.id as project_task_id,
-            project_id,
-            task_type_id,
-            base_url,
-            external_system_id,
-            external_task_id,
-            progress_info,
-            progress_info_modified,
-            es.short_name as task_provider_name
-        FROM public.projects_projecttask pt
-        JOIN projects_externalsystem es on pt.external_system_id = es.id
-        WHERE pt.id = %s
-    '''
-    return execute_query(sql, (str(project_task_id),), correlation_id)
+    return execute_query(GET_PROJECT_TASK_SQL, (str(project_task_id),), correlation_id)
 
 
-def update_project_task_progress_info(project_task_id, progress_info_dict, progress_info_modified, correlation_id):
+def update_project_task_progress_info(project_task_id, progress_info_dict, progress_info_modified, correlation_id=None):
     progress_info_json = json.dumps(progress_info_dict)
-
-    base_sql = '''
-                UPDATE public.projects_projecttask
-                SET progress_info = (%s), progress_info_modified = (%s)
-                WHERE id = (%s);
-            '''
-
-    number_of_updated_rows = execute_non_query(base_sql, [progress_info_json, progress_info_modified, project_task_id], correlation_id)
+    number_of_updated_rows = execute_non_query(UPDATE_PROJECT_TASK_PROGRESS_INFO_SQL, [progress_info_json, progress_info_modified, project_task_id],
+                                               correlation_id)
     return number_of_updated_rows
 
 
-def get_project_with_tasks(project_uuid, correlation_id):
+def get_project_with_tasks(project_uuid, correlation_id=None):
     # take base sql query and insert a where clause to get specified project
     sql_where_clause = " AND id = %s "
     # put where clause before final order by
@@ -244,79 +122,13 @@ def get_project_api(event, context):
     return response
 
 
-PROJECT_USER_SELECT_SQL = '''
-    SELECT row_to_json(project_row) 
-    from (
-        select 
-            id, 
-            short_name,
-            visibility,
-            status,
-            FALSE as project_is_visible,
-            (
-                select coalesce(json_agg(task_row), '[]'::json)
-                from (
-                    select 
-                        task.id,
-                        description,
-                        signup_status,
-                        visibility,   
-                        external_task_id,
-                        base_url as url,                    
-                        status,
-                        es.short_name as task_provider_name,
-                        FALSE as task_is_visible,
-                        FALSE as user_is_signedup,
-                        FALSE as signup_available,
-                        null as user_task_status
-                    from public.projects_projecttask task
-                    join public.projects_externalsystem es on task.external_system_id = es.id
-                    where task.project_id = project.id
-                        AND task.status != 'planned'                   
-                    order by task.created
-                    ) task_row
-            ) as tasks
-        from public.projects_project project
-        where project.status != 'planned'
-        order by created
-        ) project_row
-    '''
-
-
-def get_project_status_for_user(user_id, correlation_id):
+def get_project_status_for_user(user_id, correlation_id=None):
 
     project_list = execute_query(PROJECT_USER_SELECT_SQL, None, correlation_id, True, False)
 
-    sql0 = """
-        SELECT project_id, project_name, group_id, group_name, user_id, email
-        FROM public.project_group_users
-        WHERE user_id = %s
-    """
+    sql0, sql1, sql2, sql3, sql4 = (get_project_status_for_user_sql['sql0'], get_project_status_for_user_sql['sql1'], get_project_status_for_user_sql['sql2'],
+                                    get_project_status_for_user_sql['sql3'], get_project_status_for_user_sql['sql4'])
 
-    sql1 = """
-        SELECT project_id, project_name, testing_group_id, group_name, user_id, email
-        FROM public.project_testgroup_users
-        WHERE user_id = %s
-    """
-
-    sql2 = """
-        SELECT project_task_id, description, group_id, group_name, user_id, email
-        FROM public.projecttask_group_users
-        WHERE user_id = %s
-    """
-
-    sql3 = """
-        SELECT project_task_id, description, testing_group_id, group_name, user_id, email
-        FROM public.projecttask_testgroup_users
-        WHERE user_id = %s
-    """
-
-    sql4 = """
-        SELECT project_task_id, ut.id, ut.status
-        FROM public.projects_usertask ut
-        JOIN public.projects_userproject up ON ut.user_project_id = up.id
-        WHERE up.user_id = %s
-    """
     str_user_id = (str(user_id),)
     results = execute_query_multiple((sql0, sql1, sql2, sql3, sql4), (str_user_id, str_user_id, str_user_id, str_user_id, str_user_id), correlation_id)
 
@@ -373,42 +185,15 @@ def get_project_status_for_user(user_id, correlation_id):
     return project_list
 
 
-def get_project_status_for_external_user(ext_user_project_id, correlation_id):
+def get_project_status_for_external_user(ext_user_project_id, correlation_id=None):
 
     logger = get_logger()
 
     project_list = execute_query(PROJECT_USER_SELECT_SQL, None, correlation_id, True, False)
 
-    sql0 = """
-        SELECT project_id, project_name, group_id, group_name, user_id, email, ext_user_project_id
-        FROM public.project_group_users
-        WHERE ext_user_project_id = %s
-    """
-
-    sql1 = """
-        SELECT project_id, project_name, testing_group_id, group_name, user_id, email, ext_user_project_id
-        FROM public.project_testgroup_users
-        WHERE ext_user_project_id = %s
-    """
-
-    sql2 = """
-        SELECT project_task_id, description, group_id, group_name, user_id, email, ext_user_project_id
-        FROM public.projecttask_group_users
-        WHERE ext_user_project_id = %s
-    """
-
-    sql3 = """
-        SELECT project_task_id, description, testing_group_id, group_name, user_id, email, ext_user_project_id
-        FROM public.projecttask_testgroup_users
-        WHERE ext_user_project_id = %s
-    """
-
-    sql4 = """
-        SELECT project_task_id, ut.id, ut.status, up.ext_user_project_id as ext_user_project_id, ut.ext_user_task_id as ext_user_task_id 
-        FROM public.projects_usertask ut
-        JOIN public.projects_userproject up ON ut.user_project_id = up.id
-        WHERE ext_user_project_id = %s
-    """
+    sql0, sql1, sql2, sql3, sql4 = (get_project_status_for_external_user_sql['sql0'], get_project_status_for_external_user_sql['sql1'],
+                                    get_project_status_for_external_user_sql['sql2'], get_project_status_for_external_user_sql['sql3'],
+                                    get_project_status_for_external_user_sql['sql4'])
 
     tuple_ext_user_project_id = (str(ext_user_project_id),)
     results = execute_query_multiple(
@@ -556,39 +341,3 @@ def get_project_status_for_external_user_api(event, context):
 
     logger.info('API response', extra={'response': response, 'correlation_id': correlation_id, 'elapsed_ms': get_elapsed_ms(start_time)})
     return response
-
-
-if __name__ == "__main__":
-    # result = get_project_with_tasks('5907275b-6d75-4ec0-ada8-5854b44fb955',None)
-
-    # result = get_project_task("07af2fbe-5cd1-447f-bae1-3a2f8de82829", None)
-
-    # pp = {'id': "0c137d9d-e087-448b-ba8d-24141b6ceecd"}
-    # ev = {'pathParameters': pp}
-    # result = get_project_api(ev, None)
-
-    # result = list_projects_api(None, None)
-    # result_status = result['statusCode']
-    # result_json = json.loads(result['body'])
-
-    # result = list_publicly_visible_projects('123')
-    # j "04306e5c-b04f-4d2c-9e82-97fee2d135af"
-    # d "26ee974a-08de-4a89-a85e-bcdabc7d9944"
-    # s "6b78f0fc-9266-40fb-a212-b06889a6811d"
-    # a "a5634be4-af2a-4d4a-a282-663e8c816507"
-    # result = list_user_visible_projects("6b78f0fc-9266-40fb-a212-b06889a6811d",'123')
-    qsp = {'user_id': "8518c7ed-1df4-45e9-8dc4-d49b57ae0663"}
-    ev = {'queryStringParameters': qsp}
-    result = get_project_status_for_user_api(ev, None)
-    print(json.dumps(result, indent=2))
-    body = result['body']
-    body_json = json.loads(body)
-    print(json.dumps(body_json, indent=2))
-    # if len(result) == 0:
-    #     print(result)
-    # else:
-    #     for item in result:
-    #         print(item)
-
-    # print(list_projects_with_tasks(None))
-    # print(json.dumps(list_projects(None)))


### PR DESCRIPTION
This branch demonstrates the use of jinja2 templates to make our SQL queries code DRYer and easier to curate.

SQL queries from api.endpoints.project were moved to a separate file api.common.sql_queries and 4 jinja2 templates used to generate 8 similar SQL queries (see end of the file).

If this is the approach we would like to use, this can be expanded to manage other SQL queries.  