### PR TITLE
HubSpot timestamp bug

### DIFF
--- a/api/tests/test_scripts/integration_tests/test_user_signin.py
+++ b/api/tests/test_scripts/integration_tests/test_user_signin.py
@@ -96,10 +96,5 @@ class TestUserSignin(test_utils.DbTestCase):
         hs_client = hs.HubSpotClient()
         contact = hs_client.get_hubspot_contact_by_email(EXPECTED_USER['email'])
         login_time = contact['properties']['thiscovery_last_login_date']['value']
-        login_dt = hs.hubspot_timestamp_to_datetime(login_time)
-        login_time_delta = abs(approximate_login_time - login_dt)
-        try:
-            self.assertLess(login_time_delta.seconds, TIME_TOLERANCE_SECONDS)
-        except AssertionError:
-            # todo: investigate why HubSpot timestamps have been 1 hour earlier than utc in the last few days; then remove this try statement
-            self.assertEqual(3600, login_time_delta.seconds)
+        login_time_delta = abs(approximate_login_time - hs.hubspot_timestamp_to_datetime(login_time))
+        self.assertLess(login_time_delta.seconds, TIME_TOLERANCE_SECONDS)


### PR DESCRIPTION
Could not reproduce bug. This PR removes workaround introduced in test_user_signin.py when bug was first observed